### PR TITLE
Criação e Listagem de Usuário

### DIFF
--- a/infra/migrations/1726445066019_test-migrations.js
+++ b/infra/migrations/1726445066019_test-migrations.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1749473747090_create-users.js
+++ b/infra/migrations/1749473747090_create-users.js
@@ -1,0 +1,43 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+
+    // For reference, Github limits usernames to 39 characters.
+    username: {
+      type: "varChar(30)",
+      notNull: true,
+      unique: true,
+    },
+
+    // why 254 length? https://stackoverflow.com/a/1199238
+    email: {
+      type: "varChar(254)",
+      notNull: true,
+      unique: true,
+    },
+
+    // why 60 length? https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varChar(60)",
+      notNull: true,
+    },
+
+    // why timestamp with time zone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+
+    updated_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+  });
+};
+exports.down = (pgm) => false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -6,7 +6,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,7 @@
 import retry from "async-retry";
+import { run } from "docker-compose";
 import database from "infra/database.js";
+import migrator from "models/migrator.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -24,8 +26,13 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 };
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
  - `POST` `/api/v1/users`
  -  `GET` `/api/v1/users/[username]`
- remove `migration` de teste
- Cria dois novos errors customizados:
  - `ValidationError`
  - `NotFoundError`
- adiciona novo método ao `orchestrator`:
  -  `runPendingMigrations`
- Silencia logs do `migrator`